### PR TITLE
HTML based nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "d3": "4.9.1",
-    "networkvizjs": "git+https://github.com/SpyR1014/networkVizJS.git#e45266215a6335804f335e6a547b9371c7f23176",
+    "networkvizjs": "git+https://github.com/SpyR1014/networkVizJS.git#dd312fdfac5efef2777841e9b886b5a010374505",
     "rxjs": "5.4.1",
     "vue": "^2.3.3"
   },

--- a/src/behaviours/text-edit.js
+++ b/src/behaviours/text-edit.js
@@ -5,73 +5,6 @@
  */
 const Rx = require('rxjs');
 
-// Modal of the text
-function Text(startingText, node, restart) {
-  let text = [],
-    cursor = true;
-  if (!Array.isArray(startingText)) {
-    text.push(startingText);
-  } else {
-    // Make a copy of the array
-    text = JSON.parse(JSON.stringify(startingText));
-  }
-  return {
-    addLetter: (char) => {
-      let lastLine = text.slice(-1);
-      lastLine += char;
-      text[text.length - 1] = lastLine;
-    },
-    newLine: () => {
-      if (text[text.length - 1] === "") {
-        return;
-      }
-      text.push("");
-    },
-    deleteText: () => {
-      /**
-       * Delete a single character of text.
-       * Delete a line if it is empty.
-       */
-      if (text.length > 1) {
-        if (text[text.length - 1] === '') {
-          text = text.slice(0, -1)
-          return;
-        } else {
-          text[text.length - 1] = text[text.length - 1].slice(0, -1)
-          return;
-        }
-      } else {
-        if (text[0] === "") {
-          return;
-        }
-        text[0] = text[0].slice(0, -1);
-      }
-    },
-
-    clearText: () => {
-      if (text[0] === "New") {
-        text[0] = '';
-      }
-    },
-
-    toggleCursor: () => {
-      cursor = !cursor;
-    },
-    getWithCursor: () => {
-      let t = JSON.parse(JSON.stringify(text));
-      if (cursor) {
-        return t;
-      } else {
-        t[t.length - 1] += '|';
-        return t
-      }
-    },
-    getText: () => {
-      return JSON.parse(JSON.stringify(text));
-    }
-  }
-}
-
 /**
  * Takes an action observable.
  */
@@ -79,122 +12,121 @@ export default ($action) => {
   $action
     .filter(action => {
       return action.type === 'EDITNODE';
-    })
-    .map(action => {
-      let restart = action.restart;
-      let fullRestart = action.fullRestart;
+    }).map(action => {
+      let fullRestart = action.restart;
+      let restart = () => action.restart("NOUPDATE");
       let node = action.clickedNode;
-      let textNodes = action.textNodes;
-      let text = Text(node.shortname, node, restart);
       let deleteRadial = action.deleteRadial;
-      let oldText = node.shortname
-      text.clearText()
-      deleteRadial()
+      let oldText = node.shortname;
+      let elem = action.elem;
+      let callback = action.callback;
+
+      // block undo in graphviz usingkeyboard shortcut
+      action.canUndo(false);
+      // remove hover menu
+      deleteRadial();
+
+      elem.classList.add("allowSelection");
+
+      // select text if New else move caret to end
+      if (window.getSelection) {
+        let range = document.createRange();
+        range.selectNodeContents(elem);
+        if (elem.innerHTML !== "New") {
+          range.collapse(false);
+        }
+        let sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      } else if (document.body.createTextRange) { // IE compatability
+        let textRange = document.body.createTextRange();
+        textRange.moveToElementText(elem);
+        if (elem.innerHTML !== "New") {
+          textRange.collapse(false);
+        }
+        textRange.select();
+      }
+
+      elem.focus(); // focus on text box
+      // elem.innerText = elem.innerHTML.replace(/<br>/g, "\n").replace(/&nbsp;/g, " "); // display HTML content of node //TODO-ya determine how interaction will work
       restart();
+
+      // correct behaviour on paste
+      Rx.Observable.fromEvent(elem, "paste")
+        .do(e => {
+          e.preventDefault();
+          document.execCommand("insertText", false,e.clipboardData.getData('text/plain'));
+        }).subscribe(restart);
+
       // Exit on "esc" keypress
-      let $exit = Rx.Observable.concat(
+      let $esc = Rx.Observable.concat(
         Rx.Observable.fromEvent(document, "keyup")
           .filter(e => e.keyCode == 27)
       );
-
+      // Exit on mouseclick
       let $mouseClick = Rx.Observable.concat(
         Rx.Observable.fromEvent(document, "click")
       );
+      // Exit on focus lost
+      let blur = Rx.Observable.fromEvent(elem, "blur");
 
-      // Backspace
-      let $backspace = Rx.Observable.fromEvent(document, "keydown")
-        .filter(e => e.keyCode === 8 && e.keyCode !== 13)
-        .do(_ => text.deleteText())
-        .do(fullRestart);
+      // on exit
+      let $exit = Rx.Observable.merge(
+        $esc,
+        $mouseClick,
+        blur,
+      ).do(() => {
+        // remove selection
+        if (window.getSelection) {
+          window.getSelection().removeAllRanges();
+        } else if (document.selection) {
+          document.selection.empty()
+        }
+        //remove focus
+        document.activeElement.blur();
+
+        elem.classList.remove("allowSelection");
+      });
+
 
       // Letters
-      let $letters = Rx.Observable.fromEvent(document, "keypress")
-        .filter(e => e.keyCode !== 8 && e.keyCode !== 13)
-        .do((e) => {
-          if ((e.keyCode || e.which) === 32) {
-            e.preventDefault();
-          }
-          let event = e || window.event;
-          let char = String.fromCharCode(e.keyCode || e.which)
-          text.addLetter(char);
-        })
-        .do(fullRestart);
-
-      let $newLine = Rx.Observable.fromEvent(document, "keypress")
-        .filter(e => e.keyCode === 13)
-        .do(e => {
-          // Prevent stacking newlines. (Not supported)
-          if (node.shortname.slice(-1) === "") {
-            return;
-          }
-          text.newLine();
-        })
-        .do(fullRestart)
-
-      let $interval = Rx.Observable
-        .interval(500 /* ms */)
-        .timeInterval()
-        .do(_ => {
-          text.toggleCursor();
-        })
+      let $letters = Rx.Observable.fromEvent(document, "keyup");
+      // .filter(e => e.keyCode !== 8 && e.keyCode !== 13)
+      // .do((e) => {
+      //   // if ((e.keyCode || e.which) === 32) {
+      //   //   e.preventDefault();
+      //   // }
+      //   // let event = e || window.event;
+      //   // let char = String.fromCharCode(e.keyCode || e.which)
+      //   // text.addLetter(char);
+      // })
+      // .do(restart);
 
       // Return the typing observables merged together.
       let $typingControls = Rx.Observable.merge(
-        $backspace,
         $letters,
-        $newLine,
-        $interval
-      )
-        .do(_ => {
-          node.shortname = text.getWithCursor();
-          restart();
-        })
-        .takeUntil($mouseClick)
-        .takeUntil($exit)
-        .finally(_ => {
-          node.shortname = text.getText();
-          if (!node.shortname || node.shortname === '' ||
-            node.shortname.length === 0 || node.shortname[0] === '') {
-            node.shortname = oldText
+      ).do(() => {
+        restart()
+      }).takeUntil($exit)
+        .finally(() => {
+          action.canUndo(true);
+          // elem.innerText = elem.innerText.trim().replace(/\n/g, "<br>");
+          // elem.innerText = elem.innerHTML;
+          if (!elem.innerText || elem.innerText === '' || elem.innerText.length === 0 ||
+            elem.innerText[0] === '' || elem.innerText === oldText) {
+            elem.innerText = oldText;
+            fullRestart();
+          } else {
+            callback(elem.innerText)
           }
-          let foundIndex = textNodes.findIndex(x => x.id == node.id);
-          textNodes[foundIndex]['text'] = node.shortname;
-          fullRestart();
-        })
+        });
       return $typingControls
-    })
+    }
+  )
     .switch()
     .subscribe(
       console.log,
       console.error,
       () => console.log("FINISH")
     )
-}
-
-
-function deleteText(nodeText) {
-  /**
-   * Delete a single character of text.
-   * Delete a line if it is empty.
-   */
-  if (nodeText.length > 1) {
-    if (nodeText[nodeText.length - 1] === '') {
-      node.shortname = nodeText.slice(0, -1)
-      return;
-    } else {
-      nodeText[nodeText.length - 1] = nodeText[nodeText.length - 1].slice(0, -1)
-      return;
-    }
-  } else {
-    if (nodeText[0] === "") {
-      return
-    }
-    nodeText[0] = nodeText[0].slice(0, -1)
-  }
-}
-
-function addLetter(text, character) {
-  let lastLine = text.slice(-1);
-  lastLine += character;
-  text[text.length - 1] = lastLine;
 }

--- a/src/components/nodeList.vue
+++ b/src/components/nodeList.vue
@@ -43,5 +43,9 @@ ul {
     left: 10px;
     top: 10px;
     list-style-type: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 </style>

--- a/src/graphViz.vue
+++ b/src/graphViz.vue
@@ -45,7 +45,7 @@
   const CLEARHISTORY = "CLEARHISTORY";
   const NODEEDIT = "NODEEDIT";
   const EDGEEDIT = "EDGEEDIT";
-  const SHAPE = "SHAPE", COLOUR = "COLOUR", TEXT = "TEXT", PINNED = "PINNED";
+  const SHAPE = "SHAPE", COLOR = "COLOR", TEXT = "TEXT", DRAG = "DRAG";
 
 
   export default {
@@ -62,6 +62,7 @@
         notes: 0,
         noteObjs: [],
         dbClickCreateNode: true,
+        canKeyboardUndo: true,
         rootObservable: new Rx.Subject(),
       };
     },
@@ -74,12 +75,14 @@
         .filter(e => e.ctrlKey);
 
       ctrlDown.filter(e => e.keyCode === 90 && !e.shiftKey)
-        .subscribe(e => {
+        .filter(() => this.canKeyboardUndo)
+        .subscribe(() => {
           this.rootObservable.next({type: UNDO})
         });
 
       ctrlDown.filter(e => e.keyCode === 89 || (e.keyCode === 90 && e.shiftKey))
-        .subscribe(e => {
+        .filter(() => this.canKeyboardUndo)
+        .subscribe(() => {
           this.rootObservable.next({type: REDO})
         });
 
@@ -168,7 +171,6 @@
 
     methods: {
 
-
       actions($action) {
         const addNode = action => {
           // if no node, create new node
@@ -179,7 +181,8 @@
               nodeShape: 'rect',
               text: action.newNode.text ? action.newNode.text : 'New',
               isSnip: false,
-              fixed: true
+              fixed: true,
+              color: "#ffffff"
             };
             const indexOfNode = this.textNodes.map(v => v.id).indexOf(textNode.id);
             if (indexOfNode === -1) this.textNodes.push(textNode);
@@ -197,8 +200,8 @@
           }
         };
 
-        const delNode = node => {
-          this.graph.removeNode(node.id, this.recalculateNodesOutside);
+        const delNode = nodeId => {
+          this.graph.removeNode(nodeId, this.recalculateNodesOutside);
         };
 
         const addEdge = triplet => {
@@ -221,7 +224,7 @@
         let redoStack = [];
 
         $action
-          .do(action => console.log("action IN", action, undoStack, redoStack))
+          .do(action => console.log("action", action, undoStack, redoStack))
           .do(action => {
             if (!(action.type === UNDO || action.type === REDO)) {
               redoStack = [];
@@ -229,6 +232,7 @@
           })
           .map(action => {
             switch (action.type) {
+              // each action MUST push an action to the undo stack.
 
               case UNDO: {
                 if (undoStack.length > 0) {
@@ -266,18 +270,17 @@
                 let node = addNode(action);
                 undoStack.push({
                   type: DELETENODE,
-                  node: node
+                  id: node.id
                 });
                 break;
               }
 
-
               case DELETENODE: {
                 // get all edges attached to node
                 const db = this.graph.getDB();
-
+                const node = this.graph.getNode(action.id);
                 let subjectEdges = new Promise(function (resolve, reject) {
-                  db.get({subject: action.node.id}, (err, l) => {
+                  db.get({subject: node.id}, (err, l) => {
                     if (err) {
                       reject(err)
                     } else {
@@ -287,7 +290,7 @@
                 });
 
                 let objectEdges = new Promise(function (resolve, reject) {
-                  db.get({object: action.node.id}, (err, l) => {
+                  db.get({object: node.id}, (err, l) => {
                     if (err) {
                       reject(err)
                     } else {
@@ -318,10 +321,10 @@
                       });
                     }
                     // delete node
-                    delNode(action.node);
+                    delNode(node.id);
                     undoStack.push({
                       type: ADDNODE,
-                      existingNode: action.node
+                      existingNode: node
                     });
 
                     if (action.callback) {
@@ -333,7 +336,6 @@
 
                 break;
               }
-
 
               case CREATEEDGE: {
                 addEdge(action.tripletObject);
@@ -359,24 +361,53 @@
                 break;
               }
 
-              // case NODEEDIT: {
-              //   let oldProp;
-              //   switch (action.prop) {
-              //     case SHAPE: {
-              //       var foundIndex = this.textNodes.findIndex(x => x.id == action.target.id);
-              //       oldProp = this.textNodes[foundIndex].nodeShape;
-              //       this.textNodes[foundIndex].nodeShape = action.value;
-              //       this.graph.restart.styles();
-              //       break;
-              //     }
-              //     default : {
-              //       console.log("Unknown property:", action.prop)
-              //     }
-              //   }
-              //   action.value = oldProp;
-              //   undoStack.push(action);
-              //   break;
-              // }
+              case NODEEDIT: {
+                let oldProp;
+                const id = action.id;
+                const node = this.graph.getNode(id);
+                const foundIndex = this.textNodes.findIndex(x => x.id == id);
+                switch (action.prop) {
+
+                  case TEXT: {
+                    oldProp = node.shortname;
+                    node.shortname = action.value;
+                    this.textNodes[foundIndex].text = action.value;
+                    this.graph.restart.layout();
+                    break;
+                  }
+
+                  case PIN: {
+                    node.fixed = !node.fixed;
+                    this.textNodes[foundIndex].fixed = node.fixed;
+                    this.graph.restart.layout();
+                    break;
+                  }
+
+                  case COLOR: {
+                    const color = action.value;
+                    oldProp = this.textNodes[foundIndex].color;
+                    this.graph.updateNodeColor(id, color);
+                    this.textNodes[foundIndex].color = color;
+                    break;
+                  }
+
+                  case SHAPE: {
+                    const shape = action.value;
+                    oldProp = this.textNodes[foundIndex].nodeShape;
+                    this.graph.updateNodeShape(id, shape);
+                    this.textNodes[foundIndex].nodeShape = shape;
+                    break;
+                  }
+                  default : {
+                    console.log("Unknown property:", action.prop)
+                  }
+                }
+                if (action.value && oldProp) {
+                  action.value = oldProp;
+                }
+                undoStack.push(action);
+                break;
+              }
 
 
               default:
@@ -434,28 +465,36 @@
 
         this.graph = networkViz('graph', {
           layoutType: 'jaccardLinkLengths',
-          edgeLength: 140,
+          edgeLength: 170,
           jaccardModifier: 0.9,
           height: document.getElementById(this.$el.id).clientHeight,
           width: document.getElementById(this.$el.id).clientWidth,
           edgeSmoothness: 15,
 
           nodeToColor: function nodeToColor(d) {
-            return d.color ? d.color : "white";
+            return d.color ? d.color : "#ffffff";
           },
 
           nodeToPin: function nodeToPin(d) {
             return d.fixed ? d.fixed : false;
           },
 
-          updateNodeColor: function updateNodeColor(node) {
-            const foundIndex = me.textNodes.findIndex(x => x.id == node.id);
-            me.textNodes[foundIndex].color = node.color;
+          updateNodeColor: (node, color) => {
+            this.rootObservable.next({
+              type: NODEEDIT,
+              prop: COLOR,
+              value: color,
+              id: node.id,
+            });
           },
 
-          updateNodeShape: function updateNodeShape(node) {
-            const foundIndex = me.textNodes.findIndex(x => x.id == node.id);
-            me.textNodes[foundIndex].nodeShape = node.nodeShape;
+          updateNodeShape: (node, shape) => {
+            this.rootObservable.next({
+              type: NODEEDIT,
+              prop: SHAPE,
+              value: shape,
+              id: node.id,
+            });
           },
 
           // Shapes defined: rect, circle, capsule
@@ -530,15 +569,17 @@
           },
 
           clickPin: (node, element) => {
-            console.log(node);
-            const foundIndex = me.textNodes.findIndex(x => x.id == node.id);
-            me.textNodes[foundIndex].fixed = node.fixed;
+            this.rootObservable.next({
+              type: NODEEDIT,
+              prop: PIN,
+              id: node.id,
+            });
           },
 
           nodeRemove: (node) => {
             this.rootObservable.next({
               type: DELETENODE,
-              node: node
+              id: node.id,
             })
           },
 
@@ -591,23 +632,36 @@
         edgeEdit($mousedown);
 
         // Set the action of clicking the node:
-        this.graph.nodeOptions.setClickNode((node) => {
+        this.graph.nodeOptions.setClickNode((node, elem) => {
           // If the mouse is a pointer and a note is clicked on set edit mode.
           if (this.mouseState === POINTER && node.hash.slice(0, 5) === 'note-') {
+            const setCanUndo = bool => {
+              this.canKeyboardUndo = bool;
+            };
             this.currentNode = node;
-            // this.currentNode.shortname = prompt();
             $mousedown.next({
               type: 'EDITNODE',
               clickedNode: node,
-              restart: this.graph.restart.styles,
-              fullRestart: this.graph.restart.layout,
+              restart: this.graph.restart.layout,
               textNodes: this.textNodes,
-              deleteRadial: this.deleteRadial
+              deleteRadial: this.deleteRadial,
+              elem: elem.node().parentNode.querySelector("text"),
+              canUndo: setCanUndo,
+              callback: (newText) => {
+                this.rootObservable.next({
+                  type: NODEEDIT,
+                  prop: TEXT,
+                  value: newText,
+                  id: node.id,
+                });
+              },
             });
           }
         });
         // Initiate the text edit function
         textEdit($mousedown);
+
+        setTimeout(this.graph.restart.layout, 50); //TODO find permanent solution to nodes created wrong size upon loading
 
         if (callback !== undefined) callback();
       },
@@ -707,6 +761,7 @@
           case CLEARSCREEN: {
             this.mouseState = POINTER;
             this.clearScreen();
+            this.rootObservable.next({type: CLEARHISTORY});
             break;
           }
           case REMOVEARROWS: {
@@ -752,6 +807,12 @@
           default:
             break;
         }
+      },
+
+      updateCanvasSize() {
+        const wrapperElm = document.getElementById('xb-arg-map');
+        this.graph.canvasOptions.setWidth(wrapperElm.clientWidth);
+        this.graph.canvasOptions.setHeight(wrapperElm.clientHeight);
       },
     },
   };
@@ -850,6 +911,18 @@
 
   svg text::selection {
     background: none;
+  }
+
+  svg text.allowSelection {
+    -webkit-user-select: unset;
+    -moz-user-select: unset;
+    -ms-user-select: unset;
+    user-select: unset;
+  }
+
+  svg text.allowSelection::selection {
+    background-color: highlight;
+    color: highlighttext;
   }
 
   /*Ghazal Start*/


### PR DESCRIPTION
Major Changes:
HTML based nodes (using foreignObject)
-HTML input disabled for release
new node text editor behaviour changed to use browser's built in input
+allows for new lines, moving cursor around, internal undo/redo while editing text, copy/pasting (no right click), selecting

Undo/redo extended to allow for node pinning, changing shape, colour and text

Minor changes:
updated networkviz version
Default node colour set to #ffffff instead of "white"
Undoing deleting a node returns it to the correct position
slightly increased default edge length
temporary hack to fix nodes being created wrong size before page finishes loading
modified css to allow for highlighting while editing nodes
prevented highlighting of nodelist in top left